### PR TITLE
Update editable fields

### DIFF
--- a/api/src/utils/user-utils.js
+++ b/api/src/utils/user-utils.js
@@ -9,10 +9,21 @@ const neverViewableFields = ['oauthID', '__v'];
 // Fields that are never editable
 const neverEditableFields = ['_id', 'oauthID', '__v'];
 // Fields that non-directors cannot view for other users
-// TODO: omit notes fields once they are added to the DB
-const nonViewableFields = ['level', 'areDuesPaid'];
+const nonViewableFields = ['areDuesPaid'];
 // Fields that non-directors cannot edit for themselves
-const nonEditableFields = ['level', 'areDuesPaid'];
+const nonEditableFields = [
+  'email',
+  'level',
+  'areDuesPaid',
+  'gradYear',
+  'gradSemester',
+  'classStanding',
+  'generationYear',
+  'generationSemester',
+  'location',
+  'role',
+  'status',
+];
 
 const getViewableFields = (currentUser, memberId) => {
   const viewableFields = difference(allFields, neverViewableFields);


### PR DESCRIPTION
## Summary

Adds email, areDuesPaid, gradYear, gradSemester, classStanding, generationYear, generationSemester, location, role, status to fields that non-directors cannot edit for themselves.

Removes level from fields that non-directors cannot view for other users.

Closes #39 