### PR TITLE
Add GET note labels endpoint

### DIFF
--- a/api/src/api/notes.js
+++ b/api/src/api/notes.js
@@ -35,7 +35,6 @@ router.get(
     if (isAdmin(req.user)) {
       notes = await Note.find({}).lean();
     } else {
-
       notes = await Note.find({
         'metaData.access.viewableBy': { $in: [req.user._id.toString()] },
       }).lean();

--- a/api/src/api/notes.js
+++ b/api/src/api/notes.js
@@ -17,16 +17,13 @@ router.get(
   requireRegistered,
   errorWrap(async (req, res) => {
     let notes;
-    // Return all notes if Admin
     if (isAdmin(req.user)) {
       notes = [...Note.find({})];
     } else {
-      // TODO: check if viewableBy path must be changed
       notes = [
         ...Note.find({ viewableBy: { $in: [req.user._id.toString()] } }),
       ];
     }
-    // TODO: test if this loops across all objs or just creates array of 1 obj
     notes.forEach((note) => {
       // remove content from notes
       delete note['content'];
@@ -45,13 +42,13 @@ router.get(
   }),
 );
 
-//GET /notes/labels
+// GET /notes/labels
 router.get(
   '/labels',
   requireRegistered,
   errorWrap(async (req, res) => {
     const notes = await Note.find({});
-    let labelList = [];
+    const labelList = [];
 
     for (const note of notes) {
       for (const label of note.metaData.labels) {
@@ -64,6 +61,7 @@ router.get(
     res.status(200).json({
       success: true,
       result: labelList,
+      message: 'Notes retrieved successfully.',
     });
   }),
 );

--- a/api/src/api/notes.js
+++ b/api/src/api/notes.js
@@ -45,6 +45,29 @@ router.get(
   }),
 );
 
+//GET /notes/labels
+router.get(
+  '/labels',
+  requireRegistered,
+  errorWrap(async (req, res) => {
+    const notes = await Note.find({});
+    let labelList = [];
+
+    for (const note of notes) {
+      for (const label of note.metaData.labels) {
+        if (!labelList.includes(label)) {
+          labelList.push(label);
+        }
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      result: labelList,
+    });
+  }),
+);
+
 router.post(
   '/',
   requireLead,


### PR DESCRIPTION
## Summary

Get unique labels for all notes.

## Changes

- Endpoint that returns list of names of labels

## Requests / Responses 

**Request**
(Only for backend)
GET `/notes/labels` Returns list of unique labels

**Response**
(Only for backend)
HTTP/1.1 200 OK

```
{
  "success":true,
  "result":["1V1","Interview"]
}
```

Closes #55 
