### PR TITLE
Add edit version control for notes PUT endpoint

### DIFF
--- a/api/src/api/notes.js
+++ b/api/src/api/notes.js
@@ -95,31 +95,32 @@ router.put(
 
     // Get current version history and append latest edit
     const currentVersionHistory = await getVersionHistory(req.params.notesId);
-    currentVersionHistory.push({
-      date: Date.now(),
-      action: Note.actions.EDITED,
-      memberID: req.user._id,
-    });
+    if (currentVersionHistory) {
+      currentVersionHistory.push({
+        date: Date.now(),
+        action: Note.actions.EDITED,
+        memberID: req.user._id,
+      });
 
-    data.metaData.versionHistory = currentVersionHistory;
+      data.metaData.versionHistory = currentVersionHistory;
 
-    const updatedNote = await Note.findByIdAndUpdate(
-      req.params.notesId,
-      { $set: data },
-      { new: true },
-    );
+      const updatedNote = await Note.findByIdAndUpdate(
+        req.params.notesId,
+        { $set: data },
+        { new: true },
+      );
 
-    if (!updatedNote) {
+      res.status(200).json({
+        success: true,
+        message: 'Note successfully updated',
+        data: updatedNote,
+      });
+    } else {
       return res.status(404).json({
         success: false,
         message: 'No note with that id',
       });
     }
-    res.status(200).json({
-      success: true,
-      message: 'Note successfully updated',
-      data: updatedNote,
-    });
   }),
 );
 

--- a/api/src/api/notes.js
+++ b/api/src/api/notes.js
@@ -92,7 +92,6 @@ router.put(
   validateReqParams,
   errorWrap(async (req, res) => {
     let data = { ...req.body };
-
     // Get current version history and append latest edit
     const currentVersionHistory = await getVersionHistory(req.params.notesId);
     if (currentVersionHistory) {
@@ -107,7 +106,7 @@ router.put(
       const updatedNote = await Note.findByIdAndUpdate(
         req.params.notesId,
         { $set: data },
-        { new: true },
+        { new: true, upsert: true },
       );
 
       res.status(200).json({


### PR DESCRIPTION
## Summary

Makes it so that a put request does not purge the existing version control and adds another version control object showing the item has been edited.

## Changes

- Updated PUT request to handle version control properly



## Requests / Responses 

**Request**
(Only for backend)
PUT `/api/notes/6083436129793a1ceb38807e` Returns a list of users

```
{
    "metaData": {
        "access": {
            "viewableBy": [
                "60038c036cb5611a649e6b46"
            ],
            "editableBy": [
                "60038c036cb5611a649e6b46"
            ]
        },
        "title": "Test",
        "labels": [
            "1V1",
            "Interview"
        ],
        "referencedMembers": [
            "60038c036cb5611a649e6b46"
        ],
        "versionHistory": []
    },
    "content": "Test note"
}
```

**Response**
(Only for backend)
HTTP/1.1 200 OK

```
{
    "success": true,
    "message": "Note successfully updated",
    "data": {
        "metaData": {
            "access": {
                "viewableBy": [
                    "60038c036cb5611a649e6b46"
                ],
                "editableBy": [
                    "60038c036cb5611a649e6b46"
                ]
            },
            "title": "Test",
            "labels": [
                "1V1",
                "Interview"
            ],
            "referencedMembers": [
                "60038c036cb5611a649e6b46"
            ],
            "versionHistory": [
                {
                    "default": [],
                    "date": "2021-04-23T22:08:24.567Z",
                    "memberID": "60038c036cb5611a649e6b46",
                    "action": "CREATED",
                    "_id": "60834558ab885a1e96f0ddf4"
                },
                {
                    "default": [],
                    "date": "2021-04-23T22:09:04.147Z",
                    "memberID": "60038c036cb5611a649e6b46",
                    "action": "EDITED",
                    "_id": "60834580ab885a1e96f0ddf5"
                }
            ]
        },
        "content": "Test note",
        "_id": "60834558ab885a1e96f0ddf3",
        "__v": 0
    }
}
```

Closes #85, Closes #22
