### PR TITLE
Add ability to encrypt notes

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -26,6 +26,7 @@
     "mongodb": "^3.3.2",
     "mongoose": "^5.7.5",
     "morgan": "~1.9.1",
+    "openpgp": "^5.0.0-2",
     "passport": "^0.4.1",
     "passport-google-oauth20": "^2.0.0"
   },

--- a/api/src/api/members.js
+++ b/api/src/api/members.js
@@ -10,7 +10,7 @@ const {
   getEditableFields,
   validateField,
   validationFields,
-} = require('../utils/user-utils');
+} = require('../utils/users');
 
 const validateMemberQuery = (req, res, next) => {
   // Middleware that verifies that fields to be inserted/updated actually

--- a/api/src/middleware/notes.js
+++ b/api/src/middleware/notes.js
@@ -1,5 +1,5 @@
-const { isAdmin } = require('./auth');
 const Note = require('../models/notes');
+const { isAdmin } = require('./auth');
 
 // middleware to validate if user can edit
 const validateEditability = async (req, res, next) => {

--- a/api/src/models/notes.js
+++ b/api/src/models/notes.js
@@ -8,11 +8,20 @@ const actions = Object.freeze({
   EDITED: 'EDITED',
 });
 
+const labelsEnum = [
+  '1v1',
+  '2v1',
+  '2v2',
+  'Lead Interview',
+  'Director Interview',
+];
+
 const Notes = new mongoose.Schema({
+  encrypt: { type: Boolean, default: false },
   content: { type: String, default: null },
   metaData: {
     title: { type: String, default: null },
-    labels: { type: [String], default: [] },
+    labels: [{ type: String, enum: labelsEnum }],
     referencedMembers: { type: [String], default: [] },
     versionHistory: [
       {
@@ -35,3 +44,4 @@ const Notes = new mongoose.Schema({
 
 module.exports = mongoose.model('Notes', Notes);
 module.exports.actions = actions;
+module.exports.labelsEnum = labelsEnum;

--- a/api/src/utils/notes.js
+++ b/api/src/utils/notes.js
@@ -1,0 +1,41 @@
+const openpgp = require('openpgp');
+const { generateEncryptionPasswords } = require('./users');
+
+// encrypt a note with AES 256 encryption
+const encryptNote = async (data) => {
+  const viewerIds = [
+    ...data.metaData.access.editableBy,
+    ...data.metaData.access.viewableBy,
+  ];
+
+  const uniqueViewerIds = [...new Set(viewerIds)];
+  const passwords = await generateEncryptionPasswords(uniqueViewerIds);
+
+  const message = await openpgp.createMessage({
+    text: data.content.toString(),
+  });
+  const encrypted = await openpgp.encrypt({
+    message,
+    passwords,
+    config: { preferredCompressionAlgorithm: openpgp.enums.compression.zlib }, // compress with zlib
+  });
+  return encrypted;
+};
+
+// decrypt a note with AES 256 encryption
+const decryptNote = async (encryptedNote, encryptionPassword) => {
+  const encryptedMessage = await openpgp.readMessage({
+    armoredMessage: encryptedNote, // parse encrypted bytes
+  });
+  const { data: decrypted } = await openpgp.decrypt({
+    message: encryptedMessage,
+    passwords: [encryptionPassword], // decrypt with password
+  });
+  console.log(decrypted);
+  return decrypted;
+};
+
+module.exports = {
+  encryptNote,
+  decryptNote,
+};

--- a/api/src/utils/notes.js
+++ b/api/src/utils/notes.js
@@ -31,7 +31,6 @@ const decryptNote = async (encryptedNote, encryptionPassword) => {
     message: encryptedMessage,
     passwords: [encryptionPassword], // decrypt with password
   });
-  console.log(decrypted);
   return decrypted;
 };
 

--- a/api/src/utils/users.js
+++ b/api/src/utils/users.js
@@ -1,5 +1,5 @@
 const { difference, pick } = require('lodash');
-const Member = require('./../models/member');
+const Member = require('../models/member');
 const { isDirector } = require('../middleware/auth');
 
 // All fields in Member
@@ -67,6 +67,15 @@ const validateField = (field, value, validatingFields) => {
   return true;
 };
 
+// Generates encryption passwords as a combination of the unique oauthID and UIN
+const generateEncryptionPasswords = async (memberIds, db) => {
+  const members = await Member.find({ _id: { $in: memberIds } });
+  const encryptionPasswords = members.map(
+    (member) => member.oauthID + member.UIN,
+  );
+  return encryptionPasswords;
+};
+
 module.exports = {
   allFields,
   getEditableFields,
@@ -74,4 +83,5 @@ module.exports = {
   filterViewableFields,
   validateField,
   validationFields,
+  generateEncryptionPasswords,
 };

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -728,6 +728,16 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+asn1.js@^5.0.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -917,6 +927,11 @@ bluebird@^3.5.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+bn.js@^4.0.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 body-parser@1.18.3:
   version "1.18.3"
@@ -2433,7 +2448,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3454,6 +3469,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+minimalistic-assert@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
 minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -3770,6 +3790,13 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+openpgp@^5.0.0-2:
+  version "5.0.0-2"
+  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-5.0.0-2.tgz#da54385eb9298c259bc6aa76ab556532298897d4"
+  integrity sha512-es+5A50Y+4JbtV+eugLPW9v/UkUIOufeOUyTcjbG8SMILNaLY9nEwUSJKDjQOadY+16w7Uqt0FDQ3Z1Vq7/F9g==
+  dependencies:
+    asn1.js "^5.0.0"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"

--- a/client/src/css/Note.css
+++ b/client/src/css/Note.css
@@ -21,6 +21,14 @@ form.ui.form label {
   line-height: 2;
 }
 
+.ui.checkbox {
+  float: right;
+}
+
+.ui.checkbox label {
+  line-height: 1 !important;
+}
+
 /* Draft.js Wrapper */
 
 #note-editor-wrapper {

--- a/client/src/pages/Note.js
+++ b/client/src/pages/Note.js
@@ -105,7 +105,7 @@ function Note({ user }) {
   const [referencedMembers, setReferencedMembers] = useState([]);
   const [viewableBy, setViewableBy] = useState([]);
   const [editableBy, setEditableBy] = useState([]);
-  const [encryptNote, setEncryptNote] = useState(false);
+  const [encryptNote, setEncryptNote] = useState(true);
 
   // TODO: Implement safety guards for leaving an edited form
   // We can use a window.confirm() here or a semantic modal instead
@@ -146,7 +146,6 @@ function Note({ user }) {
           setReferencedMembers(currentReferencedMembers.map((m) => m.memberId));
           setViewableBy(currentViewableBy.map((m) => m.memberId));
           setEditableBy(currentEditableBy.map((m) => m.memberId));
-          console.log(encrypt);
           setEncryptNote(encrypt);
 
           // check if current user is in editor list

--- a/client/src/pages/Note.js
+++ b/client/src/pages/Note.js
@@ -16,6 +16,7 @@ import {
   Grid,
   Card,
   Message,
+  Checkbox,
 } from 'semantic-ui-react';
 import 'draft-js/dist/Draft.css';
 import PropTypes from 'prop-types';
@@ -25,7 +26,7 @@ import EditorToolbar from '../components/notes/EditorToolbar';
 import Page from '../components/layout/Page';
 import Loading from '../components/ui/Loading';
 import {
-  getNotes,
+  getNote,
   createNote,
   updateNote,
   deleteNote,
@@ -104,6 +105,7 @@ function Note({ user }) {
   const [referencedMembers, setReferencedMembers] = useState([]);
   const [viewableBy, setViewableBy] = useState([]);
   const [editableBy, setEditableBy] = useState([]);
+  const [encryptNote, setEncryptNote] = useState(false);
 
   // TODO: Implement safety guards for leaving an edited form
   // We can use a window.confirm() here or a semantic modal instead
@@ -120,12 +122,8 @@ function Note({ user }) {
       // if note is not new request template
       // data for editing an existing note
       if (noteID !== 'new') {
-        const {
-          data: { result },
-        } = await getNotes();
-
-        // see if the URL param ID matches an existing note
-        const currentNote = result.find((note) => note._id === noteID);
+        const resp = await getNote(noteID);
+        const currentNote = resp.data.result;
         if (currentNote) {
           setNoteState(NOTE_STATE.editing);
           const {
@@ -139,6 +137,7 @@ function Note({ user }) {
               },
             },
             content,
+            encrypt,
           } = currentNote;
 
           // TODO! Migrate to Form library for validation + modeling
@@ -147,6 +146,8 @@ function Note({ user }) {
           setReferencedMembers(currentReferencedMembers.map((m) => m.memberId));
           setViewableBy(currentViewableBy.map((m) => m.memberId));
           setEditableBy(currentEditableBy.map((m) => m.memberId));
+          console.log(encrypt);
+          setEncryptNote(encrypt);
 
           // check if current user is in editor list
           if (
@@ -241,10 +242,10 @@ function Note({ user }) {
     }
 
     setSubmitState(SUBMIT_STATE.start);
-
     (noteState === NOTE_STATE.editing ? updateNote : createNote)(
       {
         content: JSON.stringify(convertToRaw(editorState.getCurrentContent())),
+        encrypt: encryptNote,
         metaData: {
           title: noteTitle,
           labels: noteLabels,
@@ -428,7 +429,6 @@ function Note({ user }) {
                         {isEditable ? (
                           <Dropdown
                             value={editableBy}
-                            placeholder="Albert Cao, etc"
                             onChange={(_, { value }) => setEditableBy(value)}
                             fluid
                             multiple
@@ -441,6 +441,19 @@ function Note({ user }) {
                             subList={editableBy}
                             parentList={members}
                           />
+                        )}
+                      </label>
+                    </Form.Field>
+                    <Form.Field>
+                      <label>
+                        Encrypt Note
+                        {isEditable ? (
+                          <Checkbox
+                            checked={encryptNote}
+                            onClick={(_, data) => setEncryptNote(data.checked)}
+                          />
+                        ) : (
+                          <Checkbox checked={encryptNote} readOnly />
                         )}
                       </label>
                     </Form.Field>

--- a/client/src/utils/apiWrapper.js
+++ b/client/src/utils/apiWrapper.js
@@ -123,7 +123,22 @@ export const updateMember = (member, memberID) => {
     }));
 };
 
-// Retrieves all notes
+// Retrieves a note by ID
+export const getNote = (noteID) => {
+  const requestString = `${BACKEND_BASE_URL}/notes/${noteID}`;
+  return axios
+    .get(requestString, {
+      headers: {
+        'Content-Type': 'application/JSON',
+      },
+    })
+    .catch((error) => ({
+      type: 'GET_NOTE_FAIL',
+      error,
+    }));
+};
+
+// Retrieves notes info
 export const getNotes = () => {
   const requestString = `${BACKEND_BASE_URL}/notes`;
   return axios


### PR DESCRIPTION
## Summary

Optionally, notes are encrypted using AES 256-bit encryption. Ideally, this should deter looking through the shared Atlas / snooping interview notes in the API, while allowing for continued ease of development without a mockdb and not allowing anyone (even a director) complete access to notes.

## Screenshots

<img width="1246" alt="Screen Shot 2021-05-09 at 5 00 31 AM" src="https://user-images.githubusercontent.com/18171421/117568276-0838a100-b085-11eb-82af-7decabf036dd.png">
<img width="2034" alt="Screen Shot 2021-05-09 at 5 02 09 AM" src="https://user-images.githubusercontent.com/18171421/117568285-0f5faf00-b085-11eb-9124-532c9d811e7b.png">
