### PR TITLE
Added number metric component

### DIFF
--- a/client/src/components/Summary/NumberMetric.jsx
+++ b/client/src/components/Summary/NumberMetric.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Select from 'react-select';
+import PropTypes from 'prop-types';
 import '../../css/Summary.css';
 
 const NumberMetric = ({ options, defaultOption, value, label }) => {
@@ -21,6 +22,13 @@ const NumberMetric = ({ options, defaultOption, value, label }) => {
       <span className="num-metric-label">{label}</span>
     </div>
   );
+};
+
+NumberMetric.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.string),
+  defaultOption: PropTypes.string,
+  value: PropTypes.number,
+  label: PropTypes.string,
 };
 
 export default NumberMetric;

--- a/client/src/components/Summary/NumberMetric.jsx
+++ b/client/src/components/Summary/NumberMetric.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Select from 'react-select';
+import '../../css/Summary.css';
+
+const NumberMetric = ({ options, defaultOption, value, label }) => {
+  const formattedOptions = options.map((option) => ({
+    value: option,
+    label: option,
+  }));
+  const formattedDefaultOption = formattedOptions.find(
+    (option) => option.value === defaultOption,
+  );
+  return (
+    <div className="num-metric-container">
+      <Select
+        options={formattedOptions}
+        defaultValue={formattedDefaultOption}
+        className="num-metric-select"
+      />
+      <span className="num-metric-big-num">{value}</span>
+      <span className="num-metric-label">{label}</span>
+    </div>
+  );
+};
+
+export default NumberMetric;

--- a/client/src/css/Summary.css
+++ b/client/src/css/Summary.css
@@ -1,0 +1,33 @@
+.num-metric-container {
+  width: 40%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 0 1px 3px 0 #d4d4d5, 0 0 0 1px #d4d4d5;
+}
+
+.num-metric-select {
+  width: 50%;
+  padding-top: 30px;
+}
+
+.num-metric-select > div {
+  border-radius: 20px;
+}
+
+.num-metric-big-num,
+.num-metric-label {
+  font-family: HK Grotesk;
+  font-weight: bold;
+  padding-top: 38px;
+}
+
+.num-metric-big-num {
+  color: #0069ca;
+  font-size: 64px;
+}
+
+.num-metric-label {
+  font-size: 24px;
+  padding-bottom: 54px;
+}

--- a/client/src/css/Summary.css
+++ b/client/src/css/Summary.css
@@ -17,8 +17,7 @@
 
 .num-metric-big-num,
 .num-metric-label {
-  font-family: HK Grotesk;
-  font-weight: bold;
+  font-family: 'HK Grotesk', Sans-Serif;
   padding-top: 38px;
 }
 


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

## Description
Added the NumberMetric component. The task description is a bit unclear, so there is currently no way to adjust the value of the metric without changing the prop passed into it. To test this component, drop the following component into whatever page you want:
```
      <NumberMetric
        options={[
          'All Chapters',
          'University of Pennsylvania',
          'University of Illinois at Urbana-Champaign',
          'Bits of Good - Georgia Tech',
          'Cornell University',
          'Boston University',
          'California Polytechnic State University',
        ]}
        value={210}
        label="members"
        defaultOption="All Chapters"
      />
```

## Screenshots
![image](https://user-images.githubusercontent.com/32073638/126884024-e5e2832c-f3b9-406f-a9a6-9fb70f795c88.png)
