### PR TITLE
Fix localhost cookie subdomain support and add member info endpoint

### DIFF
--- a/api/src/api/members.js
+++ b/api/src/api/members.js
@@ -152,6 +152,31 @@ router.get(
   }),
 );
 
+router.post(
+  '/:memberId',
+  errorWrap(async (req, res) => {
+    if (req.body.secret !== process.env.SESSION_SECRET) {
+      return res.status(401).json({
+        success: false,
+        message: 'Request is missing service secret',
+      });
+    }
+
+    const member = await Member.findById(req.params.memberId);
+    if (!member) {
+      return res.status(404).json({
+        success: false,
+        message: 'Member not found with id',
+      });
+    }
+
+    res.json({
+      success: true,
+      result: filterViewableFields(member, member),
+    });
+  }),
+);
+
 router.get(
   '/:memberId/permissions',
   requireRegistered,

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -33,6 +33,7 @@ if (environment != 'production') {
   // and allow credentials (cookies)
   app.use(cors({ origin: /localhost:\d{4}/, credentials: true }));
 }
+
 app.use(logger('dev'));
 app.use(bodyParser.json({ limit: '2.1mb' }));
 app.use(bodyParser.urlencoded({ limit: '2.1mb', extended: false }));
@@ -40,6 +41,7 @@ app.use(bodyParser.urlencoded({ limit: '2.1mb', extended: false }));
 // Session support, needed for authentication
 const sessionConfig = {
   secret: process.env.SESSION_SECRET,
+  domain: '.h4i.app'
 };
 if (environment == 'production') {
   app.set('trust proxy', 1);

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -39,10 +39,13 @@ app.use(bodyParser.json({ limit: '2.1mb' }));
 app.use(bodyParser.urlencoded({ limit: '2.1mb', extended: false }));
 
 // Session support, needed for authentication
-const sessionConfig = {
-  secret: process.env.SESSION_SECRET,
-  domain: '.h4i.app',
-};
+const sessionConfig =
+  environment == 'production'
+    ? {
+        secret: process.env.SESSION_SECRET,
+        domain: '.h4i.app',
+      }
+    : { secret: process.env.SESSION_SECRET };
 if (environment == 'production') {
   app.set('trust proxy', 1);
   sessionConfig.secure = true;

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -41,7 +41,7 @@ app.use(bodyParser.urlencoded({ limit: '2.1mb', extended: false }));
 // Session support, needed for authentication
 const sessionConfig = {
   secret: process.env.SESSION_SECRET,
-  domain: '.h4i.app'
+  domain: '.h4i.app',
 };
 if (environment == 'production') {
   app.set('trust proxy', 1);


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

This PR supports storing session secrets without the `.h4i.app` domain when running locally. It also adds an endpoint for retrieving member info from an external service.
